### PR TITLE
replace spaces with dashes in filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ psnotes
 Notes, plain and simple. 
 
 P.S. Notes.
+
+Building
+--------
+
+On ubuntu you need:
+```
+sudo apt-get install libgtk-3-dev libgee-dev valac-0.16
+```
+(dont use jsut valac on ubuntu 12.04 as that defaults to 0.14 which will give you compile errors with this src)
+

--- a/src/psnotes.vala
+++ b/src/psnotes.vala
@@ -592,7 +592,7 @@ public class Main : Window {
 		if (this.editor.lineCount() > 0 && this.editor.firstLine().strip() != ""
 				&& this.noteTitleChanged()) {
 			Zystem.debug("Oh boy, the note title changed. Let's rename that sucker.");
-			this.note.rename(this.editor.firstLine().strip(), this.editor.getText());
+			this.note.rename(this.editor.firstLine().strip().replace(" ","-"), this.editor.getText());
 			this.loadNotesList("Note title changed!");
 			this.filter.notifyAutoSave();
 		} else {


### PR DESCRIPTION
PLEASE DONT MERGE AS IS

Hi Zach, I'm a _very_ happy paid up customer of PS Notes but I needed this quick hack to replace spaces with dashes for myself as that's the convention I use for my notes files. 

If you have time, it would be great if you could incorporate this as config option, though I know that's asking alot as I myself really like the clean simplicity you have with the app right now. Maybe even as a cmd line option so as not to burden the normal UI ?

I also added quick note to README on some extra deps required to compile that I didn't already have on my 12.04 install.
